### PR TITLE
fix: ISearchBarProps 타입으로 인한 빌드 오류 해결

### DIFF
--- a/src/common/components/SearchBar.tsx
+++ b/src/common/components/SearchBar.tsx
@@ -1,7 +1,10 @@
 import Image from 'next/image';
-import React, { InputHTMLAttributes } from 'react';
+import { InputHTMLAttributes } from 'react';
 
-interface ISearchBarProps extends InputHTMLAttributes<HTMLInputElement> {}
+interface ISearchBarProps extends InputHTMLAttributes<HTMLInputElement> {
+	// 빌드 시 오류 발생으로 인해 임의로 속성을 넣음.
+	id?: string;
+}
 
 export default function SearchBar({ ...rest }: ISearchBarProps) {
 	return (


### PR DESCRIPTION
- input 속성 상속 후 추가되는 키가 없어서, eslint 오류 발생.
- 임의의 id 키 추가